### PR TITLE
path-exists should be a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "globby": "^6.0.0",
     "posthtml": "^0.9.0",
     "posthtml-load-plugins": "^0.11.2",
-    "yargs": "^5.0.0"
+    "yargs": "^5.0.0",
+    "path-exists": "^3.0.0"
   },
   "devDependencies": {
     "ava": "*",
@@ -65,7 +66,6 @@
     "np": "^2.7.0",
     "npm": "^3.10.5",
     "nyc": "^8.1.0",
-    "path-exists": "^3.0.0",
     "posthtml-bem": "^0.2.2",
     "posthtml-css-modules": "^0.1.0",
     "posthtml-custom-elements": "^1.0.3",


### PR DESCRIPTION
In a clean install of npm I was getting errors from posthtml-cli due to the transitive dependency path-exists not being found.  This should probably be in the dependencies instead of the devdependencies section of package.json, since it's required in cli.js.

I was able to make my project work properly when I manually installed path-exists.