### PR TITLE
docs: clarify external config format

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
       "test/**",
       "tmp/**",
       "lib/**",
+      ".idea/**",
       "*.{html,jpg}"
     ],
     "rules": {

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,18 @@ $ posthtml --help
 
 > **Note:** Automatically loads plug-ins with configuration from package.json using [post-load-plugins](https://github.com/post-org/post-load-plugins) if not used `--auto-off` key
 
+Also note that in case of using external config file, the config itself needs to be contained inside "posthtml" key:
+```js
+module.exports = {
+  posthtml: {
+    plugins: {
+      'posthtml-plugin': {
+        foo: 'bar'
+      }
+    }
+  }
+};
+```
 
 [posthtml-url]: http://github.com/posthtml/posthtml
 


### PR DESCRIPTION
Due to the internals of `post-load-plugins` & `post-config` the config needs to be contained inside "posthtml" key, but there is no info about that in the docs and without "posthtml" key the config is not working:
```js
module.exports = {
  posthtml: {
    plugins: {
      'posthtml-plugin': {
        foo: 'bar',
      },
    },
  },
};
```