### PR TITLE
fix: require of plugin that exports ES module

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -60,8 +60,10 @@ const read = file => new Promise(resolve => fs.readFile(file, 'utf8', (error, da
   resolve(data);
 }));
 
+const interopRequire = object => object && object.__esModule ? object.default : object;
+
 const getPlugins = config => Object.keys(config.plugins || {})
-  .map(plugin => require(plugin)(config.plugins[plugin]));
+  .map(plugin => interopRequire(require(plugin))(config.plugins[plugin]));
 
 const config = cfgResolve(cli);
 


### PR DESCRIPTION
Transpiled ES modules don’t export the default export directly as CommonJS modules, they always export an object and the default export is under the key "default" in this object.

Example of error message when plugin compiled as ES module ([posthtml-hash](https://github.com/posthtml/posthtml-hash)):
```
node_modules/posthtml-cli/lib/cli.js:23
    require(plugin)(config.plugins[plugin])
                   ^

TypeError: require(...) is not a function
    at Object.keys.map.plugin (node_modules/posthtml-cli/lib/cli.js:23:20)
    at Array.map (<anonymous>)
    at getPlugins (node_modules/posthtml-cli/lib/cli.js:21:4)
    at Object.<anonymous> (node_modules/posthtml-cli/lib/cli.js:26:1)
    at Module._compile (internal/modules/cjs/loader.js:776:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:829:12)
```