### PR TITLE
chore: [BREAKING] drop node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ node_js:
   - "node"
   - "lts/*"
   - 10
-  - 8
+  - 12
+  - 13
 
 after_success:
   - npm run coverage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 environment:
   matrix:
     - nodejs_version: "11"
+    - nodejs_version: "11"
     - nodejs_version: "10"
     - nodejs_version: "9"
-    - nodejs_version: "8"
 
 version: "{build}"
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-    - nodejs_version: "11"
+    - nodejs_version: "12"
     - nodejs_version: "11"
     - nodejs_version: "10"
     - nodejs_version: "9"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "posthtml": "lib/cli.js"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=10"
   },
   "scripts": {
     "version": "conventional-changelog -i changelog.md -s -r 0 && git add changelog.md && git commit -m \"build: update changelog\"",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "posthtml": "lib/cli.js"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10.13.0"
   },
   "scripts": {
     "version": "conventional-changelog -i changelog.md -s -r 0 && git add changelog.md && git commit -m \"build: update changelog\"",

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,5 @@
 # posthtml-cli
+
 > [PostHTML][posthtml-url] сommand line interface
 
 [![Trasiv Build Status][travis-image]][travis-url][![AppVeyor Build Status][appveyor-img]][appveyor][![node][node-image]][node-url][![NPM version][npm-image]][npm-url][![Dependency Status][depstat-image]][depstat-url][![XO code style][style]][style-url][![Coveralls Status][coveralls-image]][coveralls-url]
@@ -10,13 +11,13 @@
 ```bash
 $ npm install --global posthtml-cli
 ```
-> **Note:** This project is compatible with node v8+
 
-## Usage  
+## Usage
+
 ```bash
 $ posthtml --help
 
-  Usage: 
+  Usage:
     $ posthtml <patterns>
 
   Options:
@@ -37,6 +38,7 @@ $ posthtml --help
 ```
 
 ## Options
+
 ```json
 {
   "input": "src/*.html",
@@ -48,42 +50,31 @@ $ posthtml --help
   }
 };
 ```
-> example config *`.posthtmlrc`*
+
+> example config _`.posthtmlrc`_
 
 [posthtml-url]: http://github.com/posthtml/posthtml
-
 [pkg-q-url]: http://packagequality.com/#?package=posthtml-cli
 [pkg-q-image]: http://npm.packagequality.com/shield/posthtml-cli.svg?style=flat-square
-
 [npm-total-download-url]: https://www.npmjs.com/package/posthtml-cli
 [npm-total-download-image]: https://img.shields.io/npm/dt/posthtml-cli.svg?style=flat-square
-
 [npm-download-url]: https://www.npmjs.com/package/posthtml-cli
 [npm-download-image]: https://img.shields.io/npm/dm/posthtml-cli.svg?style=flat-square
-
 [node-url]: ""
 [node-image]: https://img.shields.io/node/v/posthtml-cli.svg?maxAge=2592000&style=flat-square
-
 [npm-url]: https://npmjs.org/package/posthtml-cli
 [npm-image]: http://img.shields.io/npm/v/posthtml-cli.svg?style=flat-square
-
 [testen-url]: https://github.com/egoist/testen
 [testen-image]: https://img.shields.io/badge/testen-passing-brightgreen.svg?style=flat-square
-
 [travis-url]: https://travis-ci.org/posthtml/posthtml-cli
 [travis-image]: http://img.shields.io/travis/posthtml/posthtml-cli/master.svg?style=flat-square&label=unix
-
-[appveyor]:     https://ci.appveyor.com/project/GitScrum/posthtml-cli
+[appveyor]: https://ci.appveyor.com/project/GitScrum/posthtml-cli
 [appveyor-img]: https://img.shields.io/appveyor/ci/GitScrum/posthtml-cli/master.svg?style=flat-square&label=windows
-
 [coveralls-url]: https://coveralls.io/r/posthtml/posthtml-cli
 [coveralls-image]: http://img.shields.io/coveralls/posthtml/posthtml-cli.svg?style=flat-square
-
 [depstat-url]: https://david-dm.org/posthtml/posthtml-cli
 [depstat-image]: https://david-dm.org/posthtml/posthtml-cli.svg?style=flat-square
-
 [depstat-dev-url]: https://david-dm.org/posthtml/posthtml-cli
 [depstat-dev-image]: https://david-dm.org/posthtml/posthtml-cli/dev-status.svg?style=flat-square
-
 [style-url]: https://github.com/sindresorhus/xo
 [style]: https://img.shields.io/badge/code_style-XO-5ed9c7.svg?style=flat-square

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,8 @@
 $ npm install --global posthtml-cli
 ```
 
+> Note: This project is compatible with node v10+
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
This PR

- removes the `nodev8` from `package.json`
- removes from `travis (CI)
- Removes the not of compatible with node 8 at the readme
- Prettier changes for Readme`

New node version supporting

## `node@10.13.0`

Supporting Link

https://nodejs.org/en/about/releases/

Few issues while running `yarn install` in the project

![image](https://user-images.githubusercontent.com/26347874/74458047-1f530800-4eaf-11ea-9296-b7707ea9f11c.png)
