### PR TITLE
feat: base option

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "rimraf lib && babel src -d lib",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "pretest": "npm run build",
-    "test": "nyc ava --verbose"
+    "test": "nyc ava --timeout=1m --verbose"
   },
   "files": [
     "lib/"

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,8 @@ $ posthtml --help
     --output -o    Output File or Folder
     --config -c    Path to config file
     --use -u       PostHTML plugin name
-    --root -r      Mirror the directory structure relative to this path in the output directory
+    --root -r      Mirror the directory structure relative to this path in the output directory(default: .)
+    --allInOutput -a Save the nesting structure for output
     --help -h      CLI Help
     --version -v   CLI Version
 
@@ -37,7 +38,8 @@ $ posthtml --help
     $ posthtml input.html -o output.html -c posthtml.js
     $ posthtml input.html -o output.html -u posthtml-bem --posthtml-bem.elemPrefix __
     $ posthtml inputFolder/*.html -o outputFolder
-    $ posthtml inputFolder/**/*.html -o outputFolder
+    $ posthtml inputFolder/**/*.html -o outputFolder -a
+    $ posthtml inputFolder/**/*.html -o outputFolder -a -r inputFolder
 ```
 
 ## Options

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ $ posthtml --help
     --output -o    Output File or Folder
     --config -c    Path to config file
     --use -u       PostHTML plugin name
+    --base -b      Mirror the directory structure relative to this path in the output directory
     --help -h      CLI Help
     --version -v   CLI Version
 

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ $ posthtml --help
     --output -o    Output File or Folder
     --config -c    Path to config file
     --use -u       PostHTML plugin name
-    --base -b      Mirror the directory structure relative to this path in the output directory
+    --root -r      Mirror the directory structure relative to this path in the output directory
     --help -h      CLI Help
     --version -v   CLI Version
 

--- a/readme.md
+++ b/readme.md
@@ -23,13 +23,13 @@ $ posthtml --help
     $ posthtml <patterns>
 
   Options:
-    --output -o    Output File or Folder
-    --config -c    Path to config file
-    --use -u       PostHTML plugin name
-    --root -r      Mirror the directory structure relative to this path in the output directory(default: .)
+    --output -o      Output File or Folder
+    --config -c      Path to config file
+    --use -u         PostHTML plugin name
+    --root -r        Mirror the directory structure relative to this path in the output directory(default: .)
     --allInOutput -a Save the nesting structure for output
-    --help -h      CLI Help
-    --version -v   CLI Version
+    --help -h        CLI Help
+    --version -v     CLI Version
 
   Examples:
     $ posthtml input.html

--- a/src/cfg-resolve.js
+++ b/src/cfg-resolve.js
@@ -4,7 +4,7 @@ import mergeOptions from 'merge-options';
 
 export default ({input, flags = {}}) => {
   const explorer = cosmiconfigSync('posthtml');
-  let {config, use, output} = flags;
+  let {config, use, output, base} = flags;
 
   if (config) {
     ({config} = explorer.load(config));
@@ -20,6 +20,7 @@ export default ({input, flags = {}}) => {
 
   return mergeOptions({
     input,
-    output
+    output,
+    base
   }, use || {}, config || {});
 };

--- a/src/cfg-resolve.js
+++ b/src/cfg-resolve.js
@@ -4,7 +4,7 @@ import mergeOptions from 'merge-options';
 
 export default ({input, flags = {}}) => {
   const explorer = cosmiconfigSync('posthtml');
-  let {config, use, output, root} = flags;
+  let {config, use, output, root, allInOutput} = flags;
 
   if (config) {
     ({config} = explorer.load(config));
@@ -21,6 +21,7 @@ export default ({input, flags = {}}) => {
   return mergeOptions({
     input,
     output,
-    root
+    root,
+    allInOutput
   }, use || {}, config || {});
 };

--- a/src/cfg-resolve.js
+++ b/src/cfg-resolve.js
@@ -4,7 +4,7 @@ import mergeOptions from 'merge-options';
 
 export default ({input, flags = {}}) => {
   const explorer = cosmiconfigSync('posthtml');
-  let {config, use, output, base} = flags;
+  let {config, use, output, root} = flags;
 
   if (config) {
     ({config} = explorer.load(config));
@@ -21,6 +21,6 @@ export default ({input, flags = {}}) => {
   return mergeOptions({
     input,
     output,
-    base
+    root
   }, use || {}, config || {});
 };

--- a/src/cli.js
+++ b/src/cli.js
@@ -13,12 +13,13 @@ const cli = meow(`
   Usage: posthtml <patterns>
 
   Options:
-    --output -o    Output File or Folder
-    --config -c    Path to config file
-    --use -u       PostHTML plugin name
-    --root -r      Mirror the directory structure relative to this path in the output directory
-    --help -h      CLI Help
-    --version -v   CLI Version
+    --output -o      Output File or Folder
+    --config -c      Path to config file
+    --use -u         PostHTML plugin name
+    --root -r        Mirror the directory structure relative to this path in the output directory(default: .)
+    --allInOutput -a Save the nesting structure for output
+    --help -h        CLI Help
+    --version -v     CLI Version
 
   Examples:
     $ posthtml input.html
@@ -27,8 +28,8 @@ const cli = meow(`
     $ posthtml input.html -o output.html -c posthtml.js
     $ posthtml input.html -o output.html -u posthtml-bem --posthtml-bem.elemPrefix __
     $ posthtml inputFolder/*.html -o outputFolder
-    $ posthtml inputFolder/**/*.html -o outputFolder
-    $ posthtml inputFolder/**/*.html -o outputFolder -r inputFolder
+    $ posthtml inputFolder/**/*.html -o outputFolder -a
+    $ posthtml inputFolder/**/*.html -o outputFolder -a -r inputFolder
 `, {
   flags: {
     config: {
@@ -53,7 +54,12 @@ const cli = meow(`
     },
     root: {
       type: 'string',
-      alias: 'r'
+      alias: 'r',
+      default: '.'
+    },
+    allInOutput: {
+      type: 'boolean',
+      alias: 'a'
     }
   }
 });
@@ -74,7 +80,7 @@ const getPlugins = config => Object.keys(config.plugins || {})
 const config = cfgResolve(cli);
 
 const processing = async file => {
-  const output = await outResolve(file, config.output, config.root);
+  const output = await outResolve(file, config.output, config.root, config.allInOutput);
   const plugins = Array.isArray(config.plugins) ? config.plugins : getPlugins(config);
 
   makeDir(path.dirname(output))

--- a/src/cli.js
+++ b/src/cli.js
@@ -16,7 +16,7 @@ const cli = meow(`
     --output -o    Output File or Folder
     --config -c    Path to config file
     --use -u       PostHTML plugin name
-    --base -b      Mirror the directory structure relative to this path in the output directory
+    --root -r      Mirror the directory structure relative to this path in the output directory
     --help -h      CLI Help
     --version -v   CLI Version
 
@@ -28,7 +28,7 @@ const cli = meow(`
     $ posthtml input.html -o output.html -u posthtml-bem --posthtml-bem.elemPrefix __
     $ posthtml inputFolder/*.html -o outputFolder
     $ posthtml inputFolder/**/*.html -o outputFolder
-    $ posthtml inputFolder/**/*.html -o outputFolder -b inputFolder
+    $ posthtml inputFolder/**/*.html -o outputFolder -r inputFolder
 `, {
   flags: {
     config: {
@@ -51,9 +51,9 @@ const cli = meow(`
       type: 'array',
       alias: 'u'
     },
-    base: {
+    root: {
       type: 'string',
-      alias: 'b'
+      alias: 'r'
     }
   }
 });
@@ -74,7 +74,7 @@ const getPlugins = config => Object.keys(config.plugins || {})
 const config = cfgResolve(cli);
 
 const processing = async file => {
-  const output = await outResolve(file, config.output, config.base);
+  const output = await outResolve(file, config.output, config.root);
   const plugins = Array.isArray(config.plugins) ? config.plugins : getPlugins(config);
 
   makeDir(path.dirname(output))

--- a/src/cli.js
+++ b/src/cli.js
@@ -80,7 +80,7 @@ const getPlugins = config => Object.keys(config.plugins || {})
 const config = cfgResolve(cli);
 
 const processing = async file => {
-  const output = await outResolve(file, config.output, config.root, config.allInOutput);
+  const output = await outResolve(file, config);
   const plugins = Array.isArray(config.plugins) ? config.plugins : getPlugins(config);
 
   makeDir(path.dirname(output))

--- a/src/cli.js
+++ b/src/cli.js
@@ -16,6 +16,7 @@ const cli = meow(`
     --output -o    Output File or Folder
     --config -c    Path to config file
     --use -u       PostHTML plugin name
+    --base -b      Mirror the directory structure relative to this path in the output directory
     --help -h      CLI Help
     --version -v   CLI Version
 
@@ -27,6 +28,7 @@ const cli = meow(`
     $ posthtml input.html -o output.html -u posthtml-bem --posthtml-bem.elemPrefix __
     $ posthtml inputFolder/*.html -o outputFolder
     $ posthtml inputFolder/**/*.html -o outputFolder
+    $ posthtml inputFolder/**/*.html -o outputFolder -b inputFolder
 `, {
   flags: {
     config: {
@@ -48,6 +50,10 @@ const cli = meow(`
     use: {
       type: 'array',
       alias: 'u'
+    },
+    base: {
+      type: 'string',
+      alias: 'b'
     }
   }
 });
@@ -68,7 +74,7 @@ const getPlugins = config => Object.keys(config.plugins || {})
 const config = cfgResolve(cli);
 
 const processing = async file => {
-  const output = await outResolve(file, config.output);
+  const output = await outResolve(file, config.output, config.base);
   const plugins = Array.isArray(config.plugins) ? config.plugins : getPlugins(config);
 
   makeDir(path.dirname(output))

--- a/src/out-resolve.js
+++ b/src/out-resolve.js
@@ -1,12 +1,13 @@
 import path from 'path';
 
-export default (input, output) => new Promise(resolve => {
+export default (input, output, base) => new Promise(resolve => {
   if (output && path.extname(output)) {
     return resolve(output);
   }
 
   if (output) {
-    return resolve(path.join(output, path.basename(input)));
+    const basePath = base ? path.resolve(input).replace(path.resolve(base), '') : path.basename(input);
+    return resolve(path.join(output, basePath));
   }
 
   resolve(input);

--- a/src/out-resolve.js
+++ b/src/out-resolve.js
@@ -1,6 +1,6 @@
 import path from 'path';
 
-export default (input, {output, root, allInOutput}) => new Promise(resolve => {
+export default (input, {output, root, allInOutput} = {}) => new Promise(resolve => {
   if (output && path.extname(output)) {
     return resolve(output);
   }
@@ -11,8 +11,9 @@ export default (input, {output, root, allInOutput}) => new Promise(resolve => {
     if (allInOutput) {
       inputPath = path.relative(root, input);
     }
+
     return resolve(path.join(output, inputPath));
   }
 
-  resolve(input);
+  return resolve(input);
 });

--- a/src/out-resolve.js
+++ b/src/out-resolve.js
@@ -1,13 +1,13 @@
 import path from 'path';
 
-export default (input, output, base) => new Promise(resolve => {
+export default (input, output, root) => new Promise(resolve => {
   if (output && path.extname(output)) {
     return resolve(output);
   }
 
   if (output) {
-    const basePath = base ? path.resolve(input).replace(path.resolve(base), '') : path.basename(input);
-    return resolve(path.join(output, basePath));
+    const rootPath = root ? path.resolve(input).replace(path.resolve(root), '') : path.basename(input);
+    return resolve(path.join(output, rootPath));
   }
 
   resolve(input);

--- a/src/out-resolve.js
+++ b/src/out-resolve.js
@@ -1,12 +1,16 @@
 import path from 'path';
 
-export default (input, output, root, allInOutput) => new Promise(resolve => {
+export default (input, {output, root, allInOutput}) => new Promise(resolve => {
   if (output && path.extname(output)) {
     return resolve(output);
   }
 
   if (output) {
-    const inputPath = allInOutput ? path.relative(root, input) : path.basename(input);
+    let inputPath = path.basename(input);
+
+    if (allInOutput) {
+      inputPath = path.relative(root, input);
+    }
     return resolve(path.join(output, inputPath));
   }
 

--- a/src/out-resolve.js
+++ b/src/out-resolve.js
@@ -1,13 +1,13 @@
 import path from 'path';
 
-export default (input, output, root) => new Promise(resolve => {
+export default (input, output, root, allInOutput) => new Promise(resolve => {
   if (output && path.extname(output)) {
     return resolve(output);
   }
 
   if (output) {
-    const rootPath = root ? path.resolve(input).replace(path.resolve(root), '') : path.basename(input);
-    return resolve(path.join(output, rootPath));
+    const inputPath = allInOutput ? path.relative(root, input) : path.basename(input);
+    return resolve(path.join(output, inputPath));
   }
 
   resolve(input);

--- a/test/expected/output-nesting-root/input-nesting-child/input-nesting.html
+++ b/test/expected/output-nesting-root/input-nesting-child/input-nesting.html
@@ -1,0 +1,1 @@
+<div>input-nesting-child/index</div>

--- a/test/expected/output-nesting-root/input-nesting.html
+++ b/test/expected/output-nesting-root/input-nesting.html
@@ -1,0 +1,1 @@
+<div>input-nesting-index</div>

--- a/test/expected/output-nesting/test/fixtures/input-nesting/input-nesting-child/input-nesting.html
+++ b/test/expected/output-nesting/test/fixtures/input-nesting/input-nesting-child/input-nesting.html
@@ -1,0 +1,1 @@
+<div>input-nesting-child/index</div>

--- a/test/expected/output-nesting/test/fixtures/input-nesting/input-nesting.html
+++ b/test/expected/output-nesting/test/fixtures/input-nesting/input-nesting.html
@@ -1,0 +1,1 @@
+<div>input-nesting-index</div>

--- a/test/fixtures/input-nesting/input-nesting-child/input-nesting.html
+++ b/test/fixtures/input-nesting/input-nesting-child/input-nesting.html
@@ -1,0 +1,1 @@
+<div>input-nesting-child/index</div>

--- a/test/fixtures/input-nesting/input-nesting.html
+++ b/test/fixtures/input-nesting/input-nesting.html
@@ -1,0 +1,1 @@
+<div>input-nesting-index</div>

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -201,3 +201,43 @@ test('Transform html stdin options only config one-io anf plugins array', async 
     (await read('test/fixtures/by-config/one-io-and-plugins-array/input.html'))
   );
 });
+
+test('Output with keeping the folder structure with allInOutput option', async t => {
+  t.plan(3);
+  await execa(cli, [
+    'test/fixtures/input-nesting/**/*.html',
+    '-o',
+    'test/expected/output-nesting',
+    '-a'
+  ]);
+  t.true(await pathExists('test/expected/output-nesting'));
+  t.is(
+    (await read('test/fixtures/input-nesting/input-nesting.html')),
+    (await read('test/expected/output-nesting/test/fixtures/input-nesting/input-nesting.html'))
+  );
+  t.is(
+    (await read('test/fixtures/input-nesting/input-nesting-child/input-nesting.html')),
+    (await read('test/expected/output-nesting/test/fixtures/input-nesting/input-nesting-child/input-nesting.html'))
+  );
+});
+
+test('Specify the root of the output folder structure with root option', async t => {
+  t.plan(3);
+  await execa(cli, [
+    'test/fixtures/input-nesting/**/*.html',
+    '-o',
+    'test/expected/output-nesting-root',
+    '-a',
+    '-r',
+    'test/fixtures/input-nesting'
+  ]);
+  t.true(await pathExists('test/expected/output-nesting-root'));
+  t.is(
+    (await read('test/fixtures/input-nesting/input-nesting.html')),
+    (await read('test/expected/output-nesting-root/input-nesting.html'))
+  );
+  t.is(
+    (await read('test/fixtures/input-nesting/input-nesting-child/input-nesting.html')),
+    (await read('test/expected/output-nesting-root/input-nesting-child/input-nesting.html'))
+  );
+});

--- a/test/test-out-resolve.js
+++ b/test/test-out-resolve.js
@@ -20,11 +20,11 @@ test('only input should return tmp/file.ext', async t => {
 });
 
 test('input file and output file should return output.ext', async t => {
-  t.is(await outResolve('file.ext', 'output.ext'), 'output.ext');
+  t.is(await outResolve('file.ext', {output: 'output.ext'}), 'output.ext');
 });
 
 test('input file and output folder should return tmp/file.ext', async t => {
-  t.is(await outResolve('file.ext', 'tmp'), path.normalize('tmp/file.ext'));
+  t.is(await outResolve('file.ext', {output: 'tmp'}), path.normalize('tmp/file.ext'));
 });
 
 test('input files and output folder should return tmp/test/*.ext', async t => {
@@ -32,10 +32,10 @@ test('input files and output folder should return tmp/test/*.ext', async t => {
 });
 
 test('input files and output file should return output.ext', async t => {
-  t.is(await outResolve('test/*', 'output.ext'), 'output.ext');
+  t.is(await outResolve('test/*', {output: 'output.ext'}), 'output.ext');
 });
 
 test('input files and output file should return tmp/output.ext', async t => {
-  t.is(await outResolve('test/*', 'tmp/output.ext'), 'tmp/output.ext');
+  t.is(await outResolve('test/*', {output: 'tmp/output.ext'}), 'tmp/output.ext');
 });
 


### PR DESCRIPTION
## before

```
└── src
    ├── about
    │   └── index.html
    └── index.html
```

```
posthtml src/**/*.html -o dist
```

👇 

```
├── dist
└ index.html 
```

The directory structure was not maintained and the same file name was overwritten. 😢 
So I added the base option.
The [postcss-cli](https://github.com/postcss/postcss-cli#usage) also has an equivalent feature, which I referred to.

## after

```
└── src
    ├── about
    │   └── index.html
    └── index.html
```

```
posthtml src/**/*.html -o dist -b src
```

```
└── dist
    ├── about
    │   └── index.html
    └── index.html
```